### PR TITLE
Add more test cases for rtrim

### DIFF
--- a/test/src/test_utils_text_h.cpp
+++ b/test/src/test_utils_text_h.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "CppUTest/TestHarness.h"
 #include "moreinttypes/utils.h"
 
@@ -52,11 +53,77 @@ TEST(Strings, RtrimLeavesEmptyStringsUnchanged)
     STRCMP_EQUAL("", text);
 }
 
-TEST(Strings, LtrimRemovesLeftStartSpaces)
+TEST(Strings, RtrimLeavesStringUnchanged)
 {
-    char text[] = "     some string";
+    char text[] = " a";
+    rtrim(text);
+    STRCMP_EQUAL(" a", text);
+}
+
+TEST(Strings, RtrimSingleCharString)
+{
+    char text[] = "a ";
+    rtrim(text);
+    STRCMP_EQUAL("a", text);
+}
+
+TEST(Strings, RtrimSingleSpaceString)
+{
+    char text[] = " ";
+    rtrim(text);
+    STRCMP_EQUAL("", text);
+}
+
+TEST(Strings, RtrimRORemovesRightEndSpaces)
+{
+    const char* text = "hello             ";
+    char buf[128] = { 0 };
+    rtrim_s(buf, text);
+    STRCMP_EQUAL("hello             ", text);
+    STRCMP_EQUAL("hello", buf);
+}
+
+TEST(Strings, RtrimROLeavesEmptyStringsUnchanged)
+{
+    const char* text = "";
+    char buf[128] = { 0 };
+    rtrim_s(buf, text);
+    STRCMP_EQUAL("", text);
+    STRCMP_EQUAL("", buf);
+}
+
+TEST(Strings, RtrimROLeavesStringUnchanged)
+{
+    const char* text = " a";
+    char buf[128] = { 0 };
+    rtrim_s(buf, text);
+    STRCMP_EQUAL(" a", text);
+    STRCMP_EQUAL(" a", buf);
+}
+
+TEST(Strings, RtrimROSingleCharString)
+{
+    const char* text = "a ";
+    char buf[128] = { 0 };
+    rtrim_s(buf, text);
+    STRCMP_EQUAL("a ", text);
+    STRCMP_EQUAL("a", buf);
+}
+
+TEST(Strings, RtrimROSingleSpaceString)
+{
+    const char* text = " ";
+    char buf[128] = { 0 };
+    rtrim_s(buf, text);
+    STRCMP_EQUAL(" ", text);
+    STRCMP_EQUAL("", buf);
+}
+
+TEST(Strings, LtrimRemovesLeftEndSpaces)
+{
+    char text[] = "             hello";
     ltrim(text);
-    STRCMP_EQUAL("some string", text);
+    STRCMP_EQUAL("hello", text);
 }
 
 TEST(Strings, LtrimLeavesEmptyStringsUnchanged)
@@ -64,4 +131,182 @@ TEST(Strings, LtrimLeavesEmptyStringsUnchanged)
     char text[] = "";
     ltrim(text);
     STRCMP_EQUAL("", text);
+}
+
+TEST(Strings, LtrimLeavesStringUnchanged)
+{
+    char text[] = "a ";
+    ltrim(text);
+    STRCMP_EQUAL("a ", text);
+}
+
+TEST(Strings, LtrimSingleCharString)
+{
+    char text[] = " a";
+    ltrim(text);
+    STRCMP_EQUAL("a", text);
+}
+
+TEST(Strings, LtrimSingleSpaceString)
+{
+    char text[] = " ";
+    ltrim(text);
+    STRCMP_EQUAL("", text);
+}
+
+TEST(Strings, LtrimRORemovesLeftEndSpaces)
+{
+    const char* text = "             hello";
+    char buf[128] = { 0 };
+    ltrim_s(buf, text);
+    STRCMP_EQUAL("             hello", text);
+    STRCMP_EQUAL("hello", buf);
+}
+
+TEST(Strings, LtrimROLeavesEmptyStringsUnchanged)
+{
+    const char* text = "";
+    char buf[128] = { 0 };
+    ltrim_s(buf, text);
+    STRCMP_EQUAL("", text);
+    STRCMP_EQUAL("", buf);
+}
+
+TEST(Strings, LtrimROLeavesStringUnchanged)
+{
+    const char* text = "a ";
+    char buf[128] = { 0 };
+    ltrim_s(buf, text);
+    STRCMP_EQUAL("a ", text);
+    STRCMP_EQUAL("a ", buf);
+}
+
+TEST(Strings, LtrimROSingleCharString)
+{
+    const char* text = " a";
+    char buf[128] = { 0 };
+    ltrim_s(buf, text);
+    STRCMP_EQUAL(" a", text);
+    STRCMP_EQUAL("a", buf);
+}
+
+TEST(Strings, LtrimROSingleSpaceString)
+{
+    const char* text = " ";
+    char buf[128] = { 0 };
+    ltrim_s(buf, text);
+    STRCMP_EQUAL(" ", text);
+    STRCMP_EQUAL("", buf);
+}
+
+TEST(Strings, TrimRemovesRightEndSpaces)
+{
+    char text[] = "hello             ";
+    trim(text);
+    STRCMP_EQUAL("hello", text);
+}
+
+TEST(Strings, TrimRemovesLeftEndSpaces)
+{
+    char text[] = "             hello";
+    trim(text);
+    STRCMP_EQUAL("hello", text);
+}
+
+TEST(Strings, TrimLeavesEmptyStringsUnchanged)
+{
+    char text[] = "";
+    trim(text);
+    STRCMP_EQUAL("", text);
+}
+
+TEST(Strings, TrimLeavesStringUnchanged)
+{
+    char text[] = "a";
+    trim(text);
+    STRCMP_EQUAL("a", text);
+}
+
+TEST(Strings, TrimSingleCharRightString)
+{
+    char text[] = "a ";
+    trim(text);
+    STRCMP_EQUAL("a", text);
+}
+
+TEST(Strings, TrimSingleCharLeftString)
+{
+    char text[] = " a";
+    trim(text);
+    STRCMP_EQUAL("a", text);
+}
+
+TEST(Strings, TrimSingleSpaceString)
+{
+    char text[] = " ";
+    trim(text);
+    STRCMP_EQUAL("", text);
+}
+
+TEST(Strings, TrimRORemovesRightEndSpaces)
+{
+    const char* text = "hello             ";
+    char buf[128] = { 0 };
+    trim_s(buf, text);
+    STRCMP_EQUAL("hello             ", text);
+    STRCMP_EQUAL("hello", buf);
+}
+
+TEST(Strings, TrimRORemovesLeftEndSpaces)
+{
+    const char* text = "             hello";
+    char buf[128] = { 0 };
+    trim_s(buf, text);
+    STRCMP_EQUAL("             hello", text);
+    STRCMP_EQUAL("hello", buf);
+}
+
+TEST(Strings, TrimROLeavesEmptyStringsUnchanged)
+{
+    const char* text = "";
+    char buf[128] = { 0 };
+    trim_s(buf, text);
+    STRCMP_EQUAL("", text);
+    STRCMP_EQUAL("", buf);
+}
+
+TEST(Strings, TrimROLeavesStringUnchanged)
+{
+    const char* text = "a";
+    char buf[128] = { 0 };
+    trim_s(buf, text);
+    STRCMP_EQUAL("a", text);
+    STRCMP_EQUAL("a", buf);
+}
+
+TEST(Strings, TrimROSingleCharRightString)
+{
+    const char* text = "a ";
+    char buf[128] = { 0 };
+    trim_s(buf, text);
+    STRCMP_EQUAL("a ", text);
+    STRCMP_EQUAL("a", buf);
+}
+
+TEST(Strings, TrimROSingleCharLeftString)
+{
+    const char* text = " a";
+    char buf[128] = { 0 };
+    trim_s(buf, text);
+    STRCMP_EQUAL(" a", text);
+    STRCMP_EQUAL("a", buf);
+}
+
+TEST(Strings, TrimROSingleSpaceString)
+{
+    const char* text = " ";
+    char buf[128] = { 0 };
+    trim_s(buf, text);
+    STRCMP_EQUAL(" ", text);
+    STRCMP_EQUAL("", buf);
 }


### PR DESCRIPTION
Follow-up of the issue described in #7 to check more cases for `rtrim` (symmetric tests may be used for `ltrim`).

Also a follow-up of the split of PR #8.